### PR TITLE
fixed classname in PushNotification.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "davibennun/laravel-push-notification",
+    "name": "altpoint/laravel-push-notification",
     "description": "Laravel package to send push notifications to mobile devices (apns, gcm)",
      "keywords": ["apns","gcm","push","notification", "laravel"],
     "authors": [

--- a/src/Davibennun/LaravelPushNotification/Facades/PushNotification.php
+++ b/src/Davibennun/LaravelPushNotification/Facades/PushNotification.php
@@ -9,6 +9,6 @@ class PushNotification extends Facade {
     *
     * @return string
     */
-    protected static function getFacadeAccessor() { return 'pushNotification'; }
+    protected static function getFacadeAccessor() { return 'PushNotification'; }
 
 }


### PR DESCRIPTION
Exception: Class pushNotification does not exist
Skipping \Davibennun\LaravelPushNotification\Facades\PushNotification.

change pushNotification to PushNotification
fixed class name in PushNotification.php