### PR TITLE
Fix bo sending push notification - Return Not Registered

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "5.*",
-        "sly/notification-pusher": "2.*"
+        "sly/notification-pusher": "dev-master"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Some times the class gives and error sending notifications. This is fixed in dependant class **dev-master**