### PR TITLE
Use latest version of sly/notification-pusher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*",
-        "sly/notification-pusher": "2.*"
+        "sly/notification-pusher": "^2.2"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Add content-available with the latest version of sly/notification-pusher (2.2.12 instead of 2.2.2)
