### PR TITLE
Change shared to singleton for supporting Laravel 5.4

### DIFF
--- a/src/Davibennun/LaravelPushNotification/LaravelPushNotificationServiceProvider.php
+++ b/src/Davibennun/LaravelPushNotification/LaravelPushNotificationServiceProvider.php
@@ -32,8 +32,7 @@ class LaravelPushNotificationServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['pushNotification'] = $this->app->share(function($app)
-        {
+        $this->app->singleton('pushNotification', function ($app) {
             return new PushNotification();
         });
     }


### PR DESCRIPTION
I updated the share to singleton because it's removed in Laravel 5.4 
Docs: https://laravel.com/docs/5.4/upgrade