### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ PushNotification::app('appNameIOS')
 ```
 Where app argument `appNameIOS` refers to defined service in config file.
 
-###Dynamic configuration and Lumen users
+### Dynamic configuration and Lumen users
 You can set the app config array directly: (keep in mind the array schema)
 ```php
 //iOS app


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
